### PR TITLE
remove extraneous (?) filter on forecast date for models, misc other …

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(calc_forecast_week_end_date)
 export(calc_target_end_date)
 export(calc_target_week_end_date)
+export(get_all_models)
 export(get_model_designations)
 export(get_plot_forecast_data)
 export(load_forecasts)

--- a/R/get_all_models.R
+++ b/R/get_all_models.R
@@ -1,16 +1,25 @@
 #' Get all valid model names
 #' 
 #' @param source string specifying where to get all valid model names
-#' Currently support "remote_hub_repo" and "zoltar".
+#' Currently support "local_hub_repo", "remote_hub_repo" and "zoltar".
 #' 
 #' @return a list of valid model names
 #' 
-get_all_models <- function(source) {
+#' @export
+get_all_models <- function(source = "zoltar", hub_repo_path) {
   
   # validate source
   source <- match.arg(source, choices = c("remote_hub_repo", "zoltar"), several.ok = FALSE)
   
-  if (source == "remote_hub_repo") {
+  if (source == "local_hub_repo") {
+    if (missing(hub_repo_path)) {
+      stop ("Error in get_all_models: Please provide a hub_repo_path")
+    }
+
+    data_processed <- file.path(hub_repo_path, "data-processed")
+    models <- list.dirs(data_processed, full.names = FALSE)
+    models <- models[nchar(models) > 0]
+  } else if (source == "remote_hub_repo") {
     # set up remote hub repo request
     req <- httr::GET("https://api.github.com/repos/reichlab/covid19-forecast-hub/git/trees/master?recursive=1")
     httr::stop_for_status(req)

--- a/R/get_model_designations.R
+++ b/R/get_model_designations.R
@@ -16,7 +16,7 @@ get_model_designations <- function(models, source, hub_repo_path) {
 
   if(source == "local_hub_repo") {
     if (missing(hub_repo_path)){
-      stop ("Error in get_model_designations: Please provice a hub_repo_path")
+      stop ("Error in get_model_designations: Please provide a hub_repo_path")
     } else {
  
       data_processed <- file.path(hub_repo_path, "data-processed")

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -109,10 +109,6 @@ load_forecasts_repo <- function(file_path, models, forecast_dates, locations, ty
         )
     }
   ) %>%
-    # only include the most recent forecast submitted in the time window
-    dplyr::group_by(model) %>%
-    dplyr::filter(forecast_date == max(forecast_date)) %>%
-    dplyr::ungroup() %>%
     tidyr::separate(target, into=c("horizon","temporal_resolution","ahead","inc_cum","death_case"),
                     remove = FALSE) %>%
     dplyr::mutate(target_end_date = as.Date(

--- a/man/get_all_models.Rd
+++ b/man/get_all_models.Rd
@@ -4,11 +4,11 @@
 \alias{get_all_models}
 \title{Get all valid model names}
 \usage{
-get_all_models(source)
+get_all_models(source = "zoltar", hub_repo_path)
 }
 \arguments{
 \item{source}{string specifying where to get all valid model names
-Currently support "remote_hub_repo" and "zoltar".}
+Currently support "local_hub_repo", "remote_hub_repo" and "zoltar".}
 }
 \value{
 a list of valid model names


### PR DESCRIPTION
…minor changes

@Serena-Wang I think there were some unnecessary lines (which I may have written, not sure) in R/load_forecasts_repo.R that filtered to keep the largest forecast date within each model.  I think these are unnecessary because when the files were read in we kept the last file for each model.  But am hoping you can make sure.