### PR TITLE
Fix bugs in model legend and color transparency in plot_forecast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Description:
     https://covid19forecasthub.org/.
 License: MIT
 Imports:
-  dplyr (>= 0.8.4), tibble (>= 2.1.3), tidyr (>= 1.0.2), MMWRweek (>= 0.1.1), lubridate (>= 1.7.4), purrr (>= 0.3.3), scoringutils (>= 0.1.5), ggplot2, magrittr, forcats, RcppRoll, colorspace, ggnewscale, zoltr (>= 0.6.5)
+  dplyr (>= 0.8.4), tibble (>= 2.1.3), tidyr (>= 1.0.2), MMWRweek (>= 0.1.1), lubridate (>= 1.7.4), purrr (>= 0.3.3), scoringutils (>= 0.1.5), ggplot2, magrittr, forcats, RcppRoll, colorspace, ggnewscale, zoltr (>= 0.6.5), grDevices, RColorBrewer
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## Changes since last release
 
-- `plot_forecast` now errors when trying to plot multiple locations without location in the facet formula.
+- `plot_forecast()` now errors when trying to plot multiple locations without location in the facet formula.
+- Fix bug that model legend is missing when the user is only plotting quantile forecasts in `plot_forecast()`. If `forecast_data` doesn't contain point forecasts, the function will look for all available medians in `forecast_data` and plot them as point forecasts. 
+- Update quantile forecast color so that color transparency will not be overwritten by `fill_transparency` in `plot_forecast()` when plotting more than five models.
 
 ## covidHubUtils 0.1.3
 

--- a/R/plot_forecast.R
+++ b/R/plot_forecast.R
@@ -211,6 +211,15 @@ plot_forecast <- function(forecast_data,
      0.5 + as.numeric(interval)/2)
   }))
   
+  # if point forecasts are not available in forecast, check if medians are available
+  # ? add a boolean parameter 
+  if (!"point" %in% forecast_data$type) {
+    if (0.5 %in% forecast_data$quantile) {
+      # plot medians instead
+      quantiles_to_plot <- append(quantiles_to_plot, 0.5)
+      warning("Warning in plot_forecast: There are no point forecasts available in forecast_data. \nThe function is plotting medians instead.")
+    }
+  }
   
   # set colors
   if (fill_by_model){
@@ -354,6 +363,7 @@ plot_forecast <- function(forecast_data,
                                        group = interaction(`Prediction Interval`, model, 
                                                            location, forecast_date),
                                        fill = interaction(`Prediction Interval`, model)),
+                # ? it rewrite transparency setting when only plotting 95% pi
                 alpha = fill_transparency,
                 show.legend=FALSE) +
       ggplot2::scale_fill_manual(name = "Prediction Interval", 
@@ -368,6 +378,12 @@ plot_forecast <- function(forecast_data,
                            alpha=0) +
       ggplot2::scale_fill_manual(name = "Prediction Interval", 
                                  values = ribbon_colors) +
+      # create a transparent layer for models legend when point forecasts are not plotted
+      # models legend will be covered if point forecasts are plotted
+      ggplot2::geom_line(data = plot_data_forecast %>%
+                           dplyr::filter(type == "quantile"),
+                         mapping = ggplot2::aes(y = upper, colour = model), alpha = 0) +
+      ggplot2::scale_color_manual(name = "Model", values = forecast_colors) +
       # reset alpha in legend fill
       ggplot2::guides(
         fill = ggplot2::guide_legend(override.aes = list(alpha = 1)))

--- a/R/plot_forecast.R
+++ b/R/plot_forecast.R
@@ -212,12 +212,10 @@ plot_forecast <- function(forecast_data,
   }))
   
   # if point forecasts are not available in forecast, check if medians are available
-  # ? add a boolean parameter 
   if (!"point" %in% forecast_data$type) {
     if (0.5 %in% forecast_data$quantile) {
       # plot medians instead
       quantiles_to_plot <- append(quantiles_to_plot, 0.5)
-      warning("Warning in plot_forecast: There are no point forecasts available in forecast_data. \nThe function is plotting medians instead.")
     }
   }
   
@@ -229,7 +227,7 @@ plot_forecast <- function(forecast_data,
       model_colors <- purrr::map(
         color_families[1:length(unique(models))],
         function(color_family){
-          getPalette = colorRampPalette(RColorBrewer::brewer.pal(4, color_family))
+          getPalette = grDevices::colorRampPalette(RColorBrewer::brewer.pal(4, color_family))
           if (colourCount < 4) {
             # choose the first few from a larger set of colors, to keep higher saturation
             getPalette(4) %>% tail(colourCount)
@@ -248,20 +246,20 @@ plot_forecast <- function(forecast_data,
       colourCount <- length(quantiles_to_plot)/2
       modelCount <- length(unique(models))
       # use 8 instead of 9 to avoid black and grey shades
-      getPalette = colorRampPalette(RColorBrewer::brewer.pal(8, "Set1"))
+      getPalette = grDevices::colorRampPalette(RColorBrewer::brewer.pal(8, "Set1"))
       model_colors <- getPalette(modelCount)
       
       ribbon_colors <- RColorBrewer::brewer.pal(4, "Greys")[1:3]
       forecast_colors <- unlist(lapply(model_colors, tail, n = 1))
       # create 95% PI color
       interval_colors <- unlist(lapply(model_colors, function(color){
-        colorspace::adjust_transparency(color, 0.3)}
+        colorspace::lighten(color, 0.4)}
         ))
     }
   } else {
     # only use blue
     colourCount = max(length(quantiles_to_plot)/2+1, 2)
-    getPalette = colorRampPalette(RColorBrewer::brewer.pal(4, "Blues"))
+    getPalette = grDevices::colorRampPalette(RColorBrewer::brewer.pal(4, "Blues"))
     blues = getPalette(colourCount)
     forecast_colors <- rep(tail(blues,1), length(unique(models)))
     interval_colors <- rep(blues[1:(length(blues)-1)],
@@ -363,11 +361,8 @@ plot_forecast <- function(forecast_data,
                                        group = interaction(`Prediction Interval`, model, 
                                                            location, forecast_date),
                                        fill = interaction(`Prediction Interval`, model)),
-                # ? it rewrite transparency setting when only plotting 95% pi
-                alpha = fill_transparency,
-                show.legend=FALSE) +
-      ggplot2::scale_fill_manual(name = "Prediction Interval", 
-                                 values = interval_colors) +
+                alpha = fill_transparency, show.legend=FALSE) +
+      ggplot2::scale_fill_manual(name = "Prediction Interval", values = interval_colors) +
       # create a transparent layer with grey colors to get prediction interval legend
       ggnewscale::new_scale_fill() +
       ggplot2::geom_ribbon(data = plot_data_forecast %>%
@@ -375,9 +370,8 @@ plot_forecast <- function(forecast_data,
                            mapping = ggplot2::aes(ymin=lower, 
                                                   ymax=upper, 
                                                   fill = `Prediction Interval`), 
-                           alpha=0) +
-      ggplot2::scale_fill_manual(name = "Prediction Interval", 
-                                 values = ribbon_colors) +
+                           alpha = 0) +
+      ggplot2::scale_fill_manual(name = "Prediction Interval", values = ribbon_colors) +
       # create a transparent layer for models legend when point forecasts are not plotted
       # models legend will be covered if point forecasts are plotted
       ggplot2::geom_line(data = plot_data_forecast %>%


### PR DESCRIPTION
- Implement both ideas in issue comment (close issue #73)
- Update color for 95% Prediction Interval so that its transparency won't be overwritten by `fill_transparency` parameter when there are more than 5 models in a plot. 
- Import libraries needed in plot_forecast()