### PR TITLE
Prevents `Error: Result 2 must be a single string, not NULL of length 0`

### DIFF
--- a/R/load_latest_forecasts_repo.R
+++ b/R/load_latest_forecasts_repo.R
@@ -79,7 +79,7 @@ load_latest_forecasts_repo <- function(file_path, models, forecast_dates,
   forecast_dates <- as.Date(forecast_dates)
   
   # get paths to all forecast files
-  forecast_files <- purrr::map_chr(
+  forecast_files <- purrr::map(
     models,
     function(model) {
       if (substr(file_path, nchar(file_path), nchar(file_path)) == "/") {
@@ -98,7 +98,7 @@ load_latest_forecasts_repo <- function(file_path, models, forecast_dates,
         return(results_path)
       }
     }
-  )
+  ) %>% unlist()
 
   # read in the forecast files
   forecasts <- load_forecast_files_repo(forecast_files)


### PR DESCRIPTION
`purrr::map_chr(.x, .f)` cannot handle NULL's returned by `.f`. I discovered this running `build_ensembles.R` from covidEnsembles with an out-of-date local repo. There may be a cleaner way to do this, but my change seems to resolve the error in this case.