### PR TITLE
Load latest forecasts repo fix

### DIFF
--- a/R/load_latest_forecasts_repo.R
+++ b/R/load_latest_forecasts_repo.R
@@ -101,7 +101,10 @@ load_latest_forecasts_repo <- function(file_path, models, forecast_dates,
   ) %>% unlist()
 
   # read in the forecast files
-  forecasts <- load_forecast_files_repo(forecast_files)
+  forecasts <- load_forecast_files_repo(forecast_files,
+    locations = locations,
+    types = types,
+    targets = targets)
 
   return(forecasts)
   

--- a/R/load_latest_forecasts_repo.R
+++ b/R/load_latest_forecasts_repo.R
@@ -79,7 +79,7 @@ load_latest_forecasts_repo <- function(file_path, models, forecast_dates,
   forecast_dates <- as.Date(forecast_dates)
   
   # get paths to all forecast files
-  forecast_files <- purrr::map_chr(
+  forecast_files <- purrr::map(
     models,
     function(model) {
       if (substr(file_path, nchar(file_path), nchar(file_path)) == "/") {
@@ -98,7 +98,7 @@ load_latest_forecasts_repo <- function(file_path, models, forecast_dates,
         return(results_path)
       }
     }
-  )
+  ) %>% unlist()
 
   # read in the forecast files
   forecasts <- load_forecast_files_repo(forecast_files)


### PR DESCRIPTION
This addresses both a problem Evan and I found while building the ensemble and a nearby problem I noticed over the weekend caused by `purrr::map_dfr` being unable to  handle NULL's.