### PR TITLE
update ECDC default returns in load_truth() and unit tests

### DIFF
--- a/man/load_from_hub_repo.Rd
+++ b/man/load_from_hub_repo.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/load_truth.R
 \name{load_from_hub_repo}
 \alias{load_from_hub_repo}
-\title{load truth data from covidData}
+\title{load truth data from a local clone of forecast hub repo}
 \usage{
 load_from_hub_repo(
   target_variable,
@@ -38,5 +38,5 @@ Currently only supports "local_hub_repo" or "remote_hub_repo".}
 a data frame with columns location, target_end_date, target_variable and value
 }
 \description{
-load truth data from covidData
+load truth data from a local clone of forecast hub repo
 }

--- a/tests/testthat/test-load_truth.R
+++ b/tests/testthat/test-load_truth.R
@@ -32,7 +32,7 @@ test_that("default selections from remote hub repo", {
     )
   ))
   # ECDC hub
-  actual_ecdc <- load_truth(hub = c("ECDC"))
+  expect_warning(actual_ecdc <- load_truth(hub = c("ECDC")))
   # weekly
   expected_ecdc_inc_case <- load_truth(
     truth_source = c("JHU"),
@@ -45,11 +45,19 @@ test_that("default selections from remote hub repo", {
     target_variable = c("inc death"),
     hub = c("ECDC")
   )
+  # daily
+  expected_ecdc_inc_hosp <- load_truth(
+    truth_source = c("ECDC"),
+    target_variable = c("inc hosp"),
+    hub = c("ECDC")
+  )
+
   expect_true(dplyr::all_equal(
     actual_ecdc,
     dplyr::bind_rows(
       expected_ecdc_inc_case,
-      expected_ecdc_inc_death
+      expected_ecdc_inc_death,
+      expected_ecdc_inc_hosp
     )
   ))
 })
@@ -171,14 +179,22 @@ test_that("handles `ECDC`source in ECDC hub correctly when loading from remote
     temporal_resolution = "daily",
     hub = c("ECDC")
   ))
-  
-  expect_equal(unique(actual$target_end_date), 
-               seq(min(actual$target_end_date), 
-                   max(actual$target_end_date), 7))
-  expect_equal(unique(weekdays(actual$target_end_date)),
-               "Saturday")
-  expect_equal(unique(weekdays(actual$week_start)),
-               "Monday")
+
+  expect_equal(
+    unique(actual$target_end_date),
+    seq(
+      min(actual$target_end_date),
+      max(actual$target_end_date), 7
+    )
+  )
+  expect_equal(
+    unique(weekdays(actual$target_end_date)),
+    "Saturday"
+  )
+  expect_equal(
+    unique(weekdays(actual$week_start)),
+    "Monday"
+  )
   expect_equal(
     unique(actual$target_end_date),
     seq(


### PR DESCRIPTION
- minor problem before the update: by default load_truth() returns truth of weekly "inc case" , weekly "inc death" and daily "inc hosp" from both "JHU" and "ECDC" sources
- With this update, the default for ECDC hub would be:
   - data_location = hub repo: return truth of weekly "inc case" , weekly "inc death" from "JHU" and  daily "inc hosp" from "ECDC".
   - data_location = covidData:  return truth of weekly "inc case"  and weekly "inc death" from "JHU".  (Because European hospitalization data is not available in covidData.)