### PR TITLE
Don't read CSV files lazily

### DIFF
--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -234,6 +234,7 @@ load_forecast_files_repo <- function(file_paths,
 
       single_forecast <- readr::read_csv(
         file_path,
+        lazy = FALSE,
         col_types = readr::cols(
           forecast_date = readr::col_date(format = ""),
           target = readr::col_character(),


### PR DESCRIPTION
Fixes #315.

We want all the contents anyway so I don't think lazy loading makes much sense here.