### PR TITLE
Performance improvements in load_forecasts_repo()

### DIFF
--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -272,15 +272,13 @@ load_forecast_files_repo <- function(file_paths,
       }
 
       single_forecast <- single_forecast %>%
-        dplyr::transmute(
-          model = model,
-          forecast_date = forecast_date,
-          location = location,
+        dplyr::mutate(
           target = tolower(target),
-          target_end_date = target_end_date,
-          type = type,
-          quantile = quantile,
-          value = value
+          model = model
+        ) %>%
+        dplyr::select(
+          model, forecast_date, location, target, target_end_date, type,
+          quantile, value
         )
 
       # drop rows with NULL in value column

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -235,9 +235,7 @@ load_forecast_files_repo <- function(file_paths,
     file_paths,
     function(file_path) {
       # extract model name from file name
-      model <- strsplit(file_path, .Platform$file.sep) %>%
-        `[[`(1) %>%
-        tail(1)
+      model <- basename(file_path)
       date_start_ind <- regexpr("\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d\\-", model)
       if (date_start_ind == -1) {
         stop("In load_forecast_files_repo, incorrect file name format: must include date in YYYY-MM-DD format")

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -24,8 +24,8 @@
 #' @param targets character vector of targets to retrieve, for example
 #' `c('1 wk ahead cum death', '2 wk ahead cum death')`.
 #' Default to `NULL` which stands for all valid targets.
-#' @param hub character vector, where the first element indicates the hub
-#' from which to load forecasts. Possible options are `"US"`, `"ECDC"` and `"FluSight"`.
+#' @param hub character vector indicating the hub from which to load forecasts.
+#' Possible options are `"US"`, `"ECDC"` and `"FluSight"`.
 #' @param verbose logical to print out diagnostic messages. Default is `TRUE`
 #'
 #' @return data.frame with columns `model`, `forecast_date`, `location`, `horizon`,
@@ -37,7 +37,7 @@ load_forecasts_repo <- function(file_path,
                                 models = NULL,
                                 forecast_dates = NULL,
                                 locations = NULL,
-                                types = NULL,
+                                types = c("point", "quantile"),
                                 targets = NULL,
                                 hub = c("US", "ECDC", "FluSight"),
                                 verbose = TRUE) {
@@ -66,17 +66,14 @@ load_forecasts_repo <- function(file_path,
   
   models <- sort(models, method = "radix")
   
-  hub <- match.arg(hub,
-                   choices = c("US", "ECDC", "FluSight"),
-                   several.ok = TRUE
-  )
+  hub <- match.arg(hub)
   
   # get valid location codes
-  if (hub[1] == "US") {
+  if (hub == "US") {
     valid_location_codes <- covidHubUtils::hub_locations$fips
-  } else if (hub[1] == "ECDC") {
+  } else if (hub == "ECDC") {
     valid_location_codes <- covidHubUtils::hub_locations_ecdc$location
-  } else if (hub[1] == "FluSight") {
+  } else if (hub == "FluSight") {
     valid_location_codes <- covidHubUtils::hub_locations_flusight$fips
   }
 
@@ -90,11 +87,7 @@ load_forecasts_repo <- function(file_path,
   }
 
   # validate types
-  if (!is.null(types)) {
-    types <- match.arg(types, choices = c("point", "quantile"), several.ok = TRUE)
-  } else {
-    types <- c("point", "quantile")
-  }
+  types <- match.arg(types, several.ok = TRUE)
 
   # get valid targets
   if (hub[1] == "US") {
@@ -221,10 +214,7 @@ load_forecast_files_repo <- function(file_paths,
                                      targets = NULL,
                                      hub = c("US", "ECDC", "FluSight")) {
 
-  hub <- match.arg(hub,
-                   choices = c("US", "ECDC", "FluSight"),
-                   several.ok = TRUE
-  )
+  hub <- match.arg(hub)
   
   # validate file_paths exist
   if (is.null(file_paths) | missing(file_paths)) {

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -290,7 +290,7 @@ load_forecast_files_repo <- function(file_paths,
   ) %>%
     tidyr::separate(target,
       into = c("horizon", "temporal_resolution", "ahead", "target_variable"),
-      remove = FALSE, extra = "merge"
+      sep = " ",  remove = FALSE, extra = "merge"
     ) %>%
     dplyr::select(
       model, forecast_date, location, horizon, temporal_resolution,

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -163,7 +163,7 @@ get_forecast_file_path <- function(models,
   forecast_files <- purrr::map(
     models,
     function(model) {
-      if (substr(file_path, nchar(file_path), nchar(file_path)) == "/") {
+      if (endsWith(file_path, "/")) {
         file_path <- substr(file_path, 1, nchar(file_path) - 1)
       }
 

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -218,7 +218,7 @@ load_forecast_files_repo <- function(file_paths,
   hub <- match.arg(hub)
   
   # validate file_paths exist
-  if (is.null(file_paths) | missing(file_paths)) {
+  if (is.null(file_paths) || missing(file_paths)) {
     stop("In load_forecast_files_repo, file_paths are not provided.")
   }
 

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -169,7 +169,8 @@ get_forecast_file_path <- function(models,
 
       results_path <- file.path(
         file_path,
-        paste0(model, "/", forecast_dates, "-", model, ".csv")
+        model, 
+        paste0(forecast_dates, "-", model, ".csv")
       )
       results_path <- results_path[file.exists(results_path)]
 

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -50,7 +50,7 @@ load_forecasts_repo <- function(file_path,
 
   # validate models
   all_valid_models <- list.dirs(file_path, full.names = FALSE)
-  all_valid_models <- all_valid_models[nchar(all_valid_models) > 0]
+  all_valid_models <- all_valid_models[nzchar(all_valid_models)]
   
   if (!is.null(models)) {
     invalid_models <- models[!(models %in% all_valid_models)]

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -55,9 +55,9 @@ load_forecasts_repo <- function(file_path,
   if (!is.null(models)) {
     invalid_models <- models[!(models %in% all_valid_models)]
     if (length(invalid_models) > 0) {
-      stop(paste0("\nError in load_forecasts_repo: models parameter contains invalid model name: ",
-                  invalid_models,"."
-      ))
+      stop("\nError in load_forecasts_repo: models parameter contains invalid model name: ",
+           invalid_models, "."
+      )
     }
     
   } else {
@@ -186,12 +186,11 @@ get_forecast_file_path <- function(models,
 
       if (length(results_path) == 0) {
         if (verbose) {
-          message <- paste(
+          warning(
             "Warning in get_forecast_file_path: Couldn't find forecasts for model",
             model, "on the following forceast dates:",
             forecast_dates
           )
-          warning(message)
         }
         return(NULL)
       } else {

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -292,10 +292,6 @@ load_forecast_files_repo <- function(file_paths,
       into = c("horizon", "temporal_resolution", "ahead", "target_variable"),
       sep = " ",  remove = FALSE, extra = "merge"
     ) %>%
-    dplyr::select(
-      model, forecast_date, location, horizon, temporal_resolution,
-      target_variable, target_end_date, type, quantile, value
-    ) %>%
     join_with_hub_locations(hub = hub)
   return(all_forecasts)
 }


### PR DESCRIPTION
## Summary

This PR implements relatively straightforward and uncontroversial changes with a huge impact on performance:

- Peak memory use went from 7.2 GB to 600 MB
- Computation time went from 255s to 120s

I recommend reviewing this PR commit by commit instead of looking at the complete diff directly. Each commit contains a single change and it should greatly help understanding what is happening.

## Future directions

I already identified other potential improvements but they might require more discussion:

- Shouldn't `NULL` as a `value` already be disallowed in validations so we don't have to go through:

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L297-L298

and we can load this column directly as a `double` instead of a `character`

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L267

- Similarly, the file name format would probably have already been checked in validations and we can get rid of 

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L251-L254

- In my opinion, only `load_forecasts()` (and possibly `load_forecasts_repo()`) should be exported but `load_forecast_files_repo()` shouldn't. With `load_forecast_files_repo()` as an internal function, we can get rid of the (slow) duplicated check for file existence in `load_forecast_files_repo()` and `get_forecast_file_path()`

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L181

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L235-L241

Additionally, I have a couple of questions:

- why is `read_csv()` used with `lazy = FALSE`. My understanding is that this impacts negatively the performance and should be done only when necessary. If this is truly necessary, would it be worth adding a comment there to explain why?

- do we need the `map` here?

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L118-L124

Unless I'm missing something, it doesn't look like it since it's used without it just a couple of lines below

https://github.com/reichlab/covidHubUtils/blob/3e72fa05cdffc90acdd468b59cab6c9607c4706f/R/load_forecasts_repo.R#L130-L137