### PR TITLE
Fix bugs introduced in #370

### DIFF
--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -87,6 +87,11 @@ load_forecasts_repo <- function(file_path,
   }
 
   # validate types
+  # We still have to handle this edge case manually as NULL will automatically
+  # set to choices[1], *even if several.ok = TRUE*
+  if (is.null(types)) {
+    types <- c("point", "quantile")
+  }
   types <- match.arg(types, several.ok = TRUE)
 
   # get valid targets

--- a/R/load_forecasts_repo.R
+++ b/R/load_forecasts_repo.R
@@ -290,6 +290,10 @@ load_forecast_files_repo <- function(file_paths,
       into = c("horizon", "temporal_resolution", "ahead", "target_variable"),
       sep = " ",  remove = FALSE, extra = "merge"
     ) %>%
+    dplyr::select(
+      model, forecast_date, location, horizon, temporal_resolution,
+      target_variable, target_end_date, type, quantile, value
+    ) %>%
     join_with_hub_locations(hub = hub)
   return(all_forecasts)
 }

--- a/tests/testthat/test-load_forecast_files_repo.R
+++ b/tests/testthat/test-load_forecast_files_repo.R
@@ -25,6 +25,14 @@ test_that("load_forecast_files_repo works with data-processed folder", {
                                        ))
     )
   )
+  
+  expect_named(
+    all_forecasts,
+    c("model", "forecast_date", "location", "horizon", "temporal_resolution",
+      "target_variable", "target_end_date", "type", "quantile", "value",
+      "location_name", "population", "geo_type", "geo_value", "abbreviation",
+      "full_location_name"
+    ))
 })
 
 test_that("load_forecast_files_repo works with data-forecasts folder", {


### PR DESCRIPTION
#370 introduced two issues:

- extra columns such as `ahead`
- selection of only point forecasts when `type = NULL`. I was mistaken about the behaviour of `match.arg(several.ok = TRUE)`