### PR TITLE
Update zoltr dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Imports:
     RcppRoll,
     colorspace,
     ggnewscale,
-    zoltr (>= 0.9.1),
+    zoltr (>= 1.0.0),
     grDevices,
     RColorBrewer,
     stats,


### PR DESCRIPTION
Noting that due to semantic versioning discrepancies with zoltr, the dependency currently present (0.9.1) means that some versions of zoltr that were released previously (e.g. 0.94) would be considered sufficient but for this dependency but actually have older code.