### PR TITLE
switch from ECDC to OWID in the European Hub

### DIFF
--- a/R/load_truth.R
+++ b/R/load_truth.R
@@ -299,7 +299,7 @@ load_truth <- function(truth_source = NULL,
         stop("Error in load_truth: The truth source you selected is not supported for US data in covidData.")
       }
     } else if (hub[1] == "ECDC") {
-      if (any("ECDC", "OWID") %in% truth_source) {
+      if (any(c("ECDC", "OWID") %in% truth_source)) {
         if ("inc hosp" %in% target_variable) {
           target_variable <- target_variable[target_variable != "inc hosp"]
           truth_source <- truth_source[!truth_source %in% c("ECDC", "OWID")]

--- a/tests/testthat/test-load_truth.R
+++ b/tests/testthat/test-load_truth.R
@@ -47,7 +47,7 @@ test_that("default selections from remote hub repo", {
   )
   # daily
   expected_ecdc_inc_hosp <- load_truth(
-    truth_source = c("ECDC"),
+    truth_source = c("OWID"),
     target_variable = c("inc hosp"),
     hub = c("ECDC")
   )


### PR DESCRIPTION
We are in the process of switching from ECDC to Our World In Data as data provider in the European Forecast Hub (https://github.com/covid19-forecast-hub-europe/covid19-forecast-hub-europe/pull/2823). This PR adapts `load_truth` to accept OWID as data source.