### PR TITLE
Issue #399: Point users to the CRAN version of scoringutils

### DIFF
--- a/.github/workflows/pr_unittest.yaml
+++ b/.github/workflows/pr_unittest.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("remotes","devtools", "rmarkdown","tidyverse","DT","here","RSocrata"))
+          devtools::install_github("epiforecasts/scoringutils@v1.2.2")
           remotes::install_deps(dependencies = NA)
         shell: Rscript {0}
       - name: Install zoltr
@@ -47,7 +48,7 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v2.1
-      - name: Checkout covidData when get_truth.R, aggregate_to_weekly.R or load_truth.R has changed 
+      - name: Checkout covidData when get_truth.R, aggregate_to_weekly.R or load_truth.R has changed
         if: >-
           ${{ contains(steps.changed-files.outputs.modified_files, 'R/get_truth.R') ||
           contains(steps.changed-files.outputs.modified_files,
@@ -58,7 +59,7 @@ jobs:
         with:
           repository: reichlab/covidData
           path: covidData
-      - name: Install covidData when get_truth.R, aggregate_to_weekly.R or load_truth.R has changed 
+      - name: Install covidData when get_truth.R, aggregate_to_weekly.R or load_truth.R has changed
         if: >-
           ${{ contains(steps.changed-files.outputs.modified_files, 'R/get_truth.R') ||
           contains(steps.changed-files.outputs.modified_files,
@@ -86,8 +87,8 @@ jobs:
         run: |
           rmarkdown::render("vignettes/covidHubUtils-overview.Rmd")
         shell: Rscript {0}
-    
-          
-        
+
+
+
 
 

--- a/.github/workflows/pr_unittest.yaml
+++ b/.github/workflows/pr_unittest.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("remotes","devtools", "rmarkdown","tidyverse","DT","here","RSocrata"))
-          devtools::install_github("epiforecasts/scoringutils")
           remotes::install_deps(dependencies = NA)
         shell: Rscript {0}
       - name: Install zoltr

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("remotes","devtools","rmarkdown","tidyverse","DT","here","RSocrata"))
+          devtools::install_github("epiforecasts/scoringutils@v1.2.2")
           remotes::install_deps(dependencies = NA)
         shell: Rscript {0}
       - name: Install zoltr

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -21,7 +21,6 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("remotes","devtools","rmarkdown","tidyverse","DT","here","RSocrata"))
-          devtools::install_github("epiforecasts/scoringutils")
           remotes::install_deps(dependencies = NA)
         shell: Rscript {0}
       - name: Install zoltr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,8 +92,7 @@ Suggests:
     knitr,
     rmarkdown
 Remotes:
-    reichlab/zoltr,
-    epiforecasts/scoringutils
+    reichlab/zoltr
 Depends: 
     R (>= 3.5.0)
 URL: https://github.com/reichlab/covidHubUtils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,6 +93,7 @@ Suggests:
     rmarkdown
 Remotes:
     reichlab/zoltr
+    epiforecasts/scoringutils@v1.2.2"
 Depends: 
     R (>= 3.5.0)
 URL: https://github.com/reichlab/covidHubUtils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -92,7 +92,7 @@ Suggests:
     knitr,
     rmarkdown
 Remotes:
-    reichlab/zoltr
+    reichlab/zoltr,
     epiforecasts/scoringutils@v1.2.2"
 Depends: 
     R (>= 3.5.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Imports:
     MMWRweek (>= 0.1.1),
     lubridate (>= 1.7.4),
     purrr (>= 0.3.3),
-    scoringutils (>= 1.0.0),
+    scoringutils (>= 1.2.2),
     ggplot2,
     magrittr,
     forcats,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,7 @@ Suggests:
     rmarkdown
 Remotes:
     reichlab/zoltr,
-    epiforecasts/scoringutils@v1.2.2"
+    epiforecasts/scoringutils@v1.2.2
 Depends: 
     R (>= 3.5.0)
 URL: https://github.com/reichlab/covidHubUtils

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The `covidHubUtils` package relies on a small number of packages, including many
 ```r
 devtools::install_github("reichlab/zoltr")
 ```
-Additional functionalities in `covidHubUtils` also rely on `scoringutils`. Please install the stable version of `scoringutils` from CRAN:
+Additional functionalities in `covidHubUtils` also rely on `scoringutils`. Please install version 1.2.2 of `scoringutils` from github:
 ``` r
-install.packages("scoringutils")
+devtools::install_github("epiforecasts/scoringutils@v1.2.2")
 ```
 Some additional functionalities in `covidHubUtils` also rely on `covidData`. Because there are daily data updates in `covidData`, please install the latest version of it before using related functions in `covidHubUtils`:
 ``` r

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The `covidHubUtils` package relies on a small number of packages, including many
 ```r
 devtools::install_github("reichlab/zoltr")
 ```
-Additional functionalities in `covidHubUtils` also rely on `scoringutils`. Because of new updates in `scoringutils` that uses functions not yet on the cran version, please install `scoringutils` from GitHub:
+Additional functionalities in `covidHubUtils` also rely on `scoringutils`. Please install the stable version of `scoringutils` from CRAN:
 ``` r
-remotes::install_github("epiforecasts/scoringutils")
+install.packages("scoringutils")
 ```
 Some additional functionalities in `covidHubUtils` also rely on `covidData`. Because there are daily data updates in `covidData`, please install the latest version of it before using related functions in `covidHubUtils`:
 ``` r

--- a/vignettes/covidHubUtils-overview.Rmd
+++ b/vignettes/covidHubUtils-overview.Rmd
@@ -433,6 +433,7 @@ The inputs to the `scored_forecasts()` include a `forecasts` data frame created 
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score forecasts against the true observed values. 
 ``` {r}
+# devtools::install_github("epiforecasts/scoringutils@v1.2.2")
 library(scoringutils)
 ```
 

--- a/vignettes/covidHubUtils-overview.Rmd
+++ b/vignettes/covidHubUtils-overview.Rmd
@@ -431,9 +431,8 @@ To find the most recent weekly forecast evaluation summary, please visit the [ev
 The inputs to the `scored_forecasts()` include a `forecasts` data frame created by `load_forecasts()` and a `truth` data frame created by `load_truth()`. 
 
 
-The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score forecasts against the true observed values. Please install and load the most up-to-date development version of `scoringutils` from GitHub:
+The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score forecasts against the true observed values. 
 ``` {r}
-remotes::install_github("epiforecasts/scoringutils")
 library(scoringutils)
 ```
 


### PR DESCRIPTION
Fixes #399 

We recently moved the scoringutils development version to the `main` branch of the GitHub repository, meaning the current GitHub version of scoringutils on `main` is ahead of the version that covidHubUtils is using. 

This PR
- updates the Readme to point users to the CRAN version of scoringutils
- updates the required version of scoringutils. I just used the latest version, but we could in principle probably also require `1.1.0` or something like that. 
- removes epiforecasts/scoringutils from the depends section in the DESCRIPTION such that the CRAN version of scoringutils is installed
- removes the link to the current development version from the vignette
- updates the github action to install the CRAN version of scoringutils

Further thoughts: 
- As mentioned in #399 we could alternatively adapt covidHubUtils to depend on a specific version of scoringutils on GitHub. scoringutils should remain stable after the next big update, but there will be one update with breaking changes in the near future. We should coordinate the release of the update to CRAN, but I the current setup probably means that there would be a few hours until everything is synced both on CRAN and on GitHub. If we want to avoid this then we could depend on a specific GitHub version of scoringutils now and then switch to depending on CRAN after the scoringutils update. 
- I wasn't sure whether this warrants a news item, but happy to add one if you think I should. 