### PR TITLE
Cleanup installs happening in the github workflows

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -21,14 +21,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("remotes","devtools", "rmarkdown","tidyverse","DT","here", "pkgdown", "textshaping"))
-          devtools::install_github("epiforecasts/scoringutils")
-          remotes::install_deps(dependencies = NA)
-        shell: Rscript {0}
-      
-      - name: Install zoltr
-        run: |
-          devtools::install_github("reichlab/zoltr")
+          install.packages(c("devtools"))
+          remotes::install_deps(dependencies = TRUE)
           devtools::install()
         shell: Rscript {0}
 

--- a/.github/workflows/pr_unittest.yaml
+++ b/.github/workflows/pr_unittest.yaml
@@ -21,13 +21,8 @@ jobs:
           key: r-${{ hashFiles('DESCRIPTION') }}
       - name: Install dependencies
         run: |
-          install.packages(c("remotes","devtools", "rmarkdown","tidyverse","DT","here","RSocrata"))
-          devtools::install_github("epiforecasts/scoringutils@v1.2.2")
-          remotes::install_deps(dependencies = NA)
-        shell: Rscript {0}
-      - name: Install zoltr
-        run: |
-          devtools::install_github("reichlab/zoltr")
+          install.packages(c("devtools"))
+          remotes::install_deps(dependencies = TRUE)
           devtools::install()
         shell: Rscript {0}
       - name: Run unit tests
@@ -85,7 +80,7 @@ jobs:
         shell: Rscript {0}
       - name: Render vignettes
         run: |
-          rmarkdown::render("vignettes/covidHubUtils-overview.Rmd")
+          devtools::build_vignettes()
         shell: Rscript {0}
 
 

--- a/.github/workflows/r_cmd_check.yaml
+++ b/.github/workflows/r_cmd_check.yaml
@@ -20,23 +20,10 @@ jobs:
           key: r-${{ hashFiles('DESCRIPTION') }}
       - name: Install dependencies
         run: |
-          install.packages(c("remotes","devtools","rmarkdown","tidyverse","DT","here","RSocrata"))
+          install.packages(c("devtools"))
           devtools::install_github("epiforecasts/scoringutils@v1.2.2")
-          remotes::install_deps(dependencies = NA)
+          devtools::install_deps(dependencies = TRUE)
         shell: Rscript {0}
-      - name: Install zoltr
-        run: |
-          devtools::install_github("reichlab/zoltr")
-          devtools::install()
-        shell: Rscript {0}
-      - name: Checkout covidData
-        uses: actions/checkout@v3
-        with:
-          repository: reichlab/covidData
-          path: covidData
-      - name: Install covidData
-        run: make recent_data
-        working-directory: ./covidData/code/data-processing
       - name: Check
         run: |
           devtools::check(args = c("--no-tests", "--no-manual", "--no-vignettes"),error_on = "error")

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 *.DS_Store
 inst/doc
+
+# pre-commit isn't part of the team workflow, so don't commit the config
+**/.pre-commit-config.yaml

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Description:
     https://covid19forecasthub.org/.
 License: MIT
 Imports:
+    covidData,
     dplyr (>= 0.8.4),
     tibble (>= 2.1.3),
     tidyr (>= 1.0.2),
@@ -86,12 +87,13 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
-Suggests: 
-    testthat,
-    covidData,
+Suggests:
+    DT,
     knitr,
-    rmarkdown
+    mockery,
+    testthat
 Remotes:
+    reichlab/covidData,
     reichlab/zoltr,
     epiforecasts/scoringutils@v1.2.2
 Depends: 

--- a/tests/testthat/test-align.R
+++ b/tests/testthat/test-align.R
@@ -1,6 +1,7 @@
-library(tidyverse)
 library(covidHubUtils)
 library(testthat)
+library(tibble)
+library(tidyr)
 
 
 #     Aug/Sep 2021
@@ -51,7 +52,7 @@ test_that("original columns preserved and new columns are correct", {
         )
     )
     reference_dates <- as.Date(c(
-        "2021-08-14", 
+        "2021-08-14",
         "2021-08-14",
         "2021-08-16",
         "2021-08-21",

--- a/vignettes/covidHubUtils-overview.Rmd
+++ b/vignettes/covidHubUtils-overview.Rmd
@@ -67,12 +67,12 @@ We have identified two central use cases for downloading data using `load_foreca
 
 2. Downloading all available forecasts for selected models that are submitted on a set of dates. This is achieved by using a vector of dates in `dates` parameter.
 
-Below are some examples of reading in data. We start by loading the `covidHubUtils` package and the `tidyverse`.
+Below are some examples of reading in data. We start by loading the `covidHubUtils` package.
 
 ```{r message=FALSE}
 library(covidHubUtils)
 library(doParallel)
-library(tidyverse)
+library(ggplot2)
 theme_set(theme_bw())
 ```
 
@@ -433,7 +433,6 @@ The inputs to the `scored_forecasts()` include a `forecasts` data frame created 
 
 The `scoringutils` package provides a collection of metrics and proper scoring rules that make it simple to score forecasts against the true observed values. 
 ``` {r}
-# devtools::install_github("epiforecasts/scoringutils@v1.2.2")
 library(scoringutils)
 ```
 


### PR DESCRIPTION
Addresses #404 

The scope of these commits is making sure that all required dependencies are in the package's DESCRIPTION instead of being explicitly installed as a workflow step (for example, DT is required to build the vignettes).

Additionally, there's some cleanup to remove workflow-based installs if they aren't being used and/or reducing the footprint (e.g., explicitly use `ggplot2` in the vignette rather than pull in the entire tidyverse).

Longer term, we have a goal to make these workflows better align to the newer ones used in the hubverse (#406 )

**note:** there are several smaller commits so it's easier to revert any breaking changes...happy to squash after approval to tidy up the commit history