### PR TITLE
fixed lubridate language dependence

### DIFF
--- a/R/date_management.R
+++ b/R/date_management.R
@@ -38,7 +38,7 @@ date_to_week_end_date <- function(forecast_date, week_offset = 0) {
 calc_forecast_week_end_date <- function(forecast_date) {
   forecast_date <- lubridate::ymd(forecast_date)
   result <- rep(NA_character_, length(forecast_date))
-  inds <- (lubridate::wday(forecast_date, label = TRUE) %in% c("Sun", "Mon"))
+  inds <- lubridate::wday(forecast_date) %in% 1:2
   result[inds] <- date_to_week_end_date(forecast_date[inds], week_offset = -1)
   result[!inds] <- date_to_week_end_date(forecast_date[!inds], week_offset = 0)
 
@@ -66,7 +66,7 @@ calc_forecast_week_end_date <- function(forecast_date) {
 calc_target_week_end_date <- function(forecast_date, horizon) {
   forecast_date <- lubridate::ymd(forecast_date)
   result <- rep(NA_character_, length(forecast_date))
-  inds <- (lubridate::wday(forecast_date, label = TRUE) %in% c("Sun", "Mon"))
+  inds <- lubridate::wday(forecast_date) %in% 1:2
 
   if (length(horizon) == 1) {
     result[inds] <- date_to_week_end_date(forecast_date[inds],


### PR DESCRIPTION
`lubridate::wday` with `label=T` returns the name of the day in the platform's preset language. Thus, running this code may fail on non-English computers. Example:
```
> lubridate::wday('2021-03-08', label=T)
[1] יום ב
```
which is Hebrew for Monday.